### PR TITLE
DOCS: Change case of save flag for npm to upper

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Get the _react-print_ component library.
 ### With npm
 
 ```sh npm
-npm install -s @onedoc/react-print
+npm install @onedoc/react-print
 ```
 
 ### With yarn

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -75,7 +75,7 @@ brew install gs graphicsmagick
 3. Install pip2pic:
 
 ```sh
-npm install --save pdf2pic
+npm install pdf2pic
 ```
 
 4. Install all dependencies:

--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -22,7 +22,7 @@ Get the react-print package locally
 <CodeGroup>
 
 ```sh npm
-npm install -s @onedoc/react-print
+npm install @onedoc/react-print
 ```
 
 ```sh yarn

--- a/docs/integrations/onedoc.mdx
+++ b/docs/integrations/onedoc.mdx
@@ -35,7 +35,7 @@ Get the Onedoc Node.js SDK
 <CodeGroup>
 
 ```sh npm
-npm install -s @onedoc/client
+npm install @onedoc/client
 ```
 
 ```sh yarn


### PR DESCRIPTION
We need to be sure in consistency of calls to install package

Of course `-S` or `--save` is not needed since specific version of npm

<img width="679" alt="image" src="https://github.com/OnedocLabs/react-print-pdf/assets/32175240/e3c91913-e5c7-4311-8376-ef93f089824e">

And if user doesn't want to save package user should use `--no-save` option

Also, when `-s` provided in lower case it will not work at all and should be `-S` with uppercase

<img width="669" alt="image" src="https://github.com/OnedocLabs/react-print-pdf/assets/32175240/c9fcb62e-3834-4242-8906-8a80acd60b09">

