### PR TITLE
Update onedoc.mdx

### DIFF
--- a/docs/integrations/onedoc.mdx
+++ b/docs/integrations/onedoc.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Onedoc"
 sidebarTitle: "Onedoc"
-description: "Use Onedoc as your primary documents genration and management providers"
+description: "Use Onedoc as your primary documents generation and management providers"
 icon: "1"
 ---
 


### PR DESCRIPTION
Added missing 'e' on description statement on the word 'generation'.