### PR TITLE
Remove server docs

### DIFF
--- a/docgen/buildExample.tsx
+++ b/docgen/buildExample.tsx
@@ -33,7 +33,7 @@ export const buildExample = async (
 \`\`\`jsx template.tsx
 import { ${component}${
     example.imports ? `, ${example.imports.join(", ")}` : ""
-  } } from "@onedoc/react-print/server";${
+  } } from "@onedoc/react-print";${
     example.externalImports ? `\n${example.externalImports.join("\n")}` : ""
   }
 

--- a/docgen/buildFileMarkdown.ts
+++ b/docgen/buildFileMarkdown.ts
@@ -105,7 +105,7 @@ ${docConfig.description ? `description: "${docConfig.description}"` : ""}
         }
       }
     } else {
-      markdown += `\`\`\`jsx\nimport { ${componentName} } from "@onedoc/react-print/server";\n\`\`\`\n\n`;
+      markdown += `\`\`\`jsx\nimport { ${componentName} } from "@onedoc/react-print";\n\`\`\`\n\n`;
     }
 
     if (

--- a/docs/components/compile.mdx
+++ b/docs/components/compile.mdx
@@ -28,7 +28,7 @@ const html = await compile(<Component />, { emotion: true });
 
 <div style={{paddingTop: "1rem", paddingBottom: "1rem"}}><CodeGroup>
 ```jsx template.tsx
-import { compile } from "@onedoc/react-print/server";
+import { compile } from "@onedoc/react-print";
 import { Button, ChakraProvider, extendTheme } from "@chakra-ui/react";
 
 <>

--- a/docs/components/css.mdx
+++ b/docs/components/css.mdx
@@ -26,7 +26,7 @@ Use a simple CSS print property to set the page size.
 
 <div style={{paddingTop: "1rem", paddingBottom: "1rem"}}><CodeGroup>
 ```jsx template.tsx
-import { CSS } from "@onedoc/react-print/server";
+import { CSS } from "@onedoc/react-print";
 
 <CSS>{`@page { size: a4 landscape; }`}</CSS>;
 
@@ -55,7 +55,7 @@ Load a Google Font using the `@import` rule.
 
 <div style={{paddingTop: "1rem", paddingBottom: "1rem"}}><CodeGroup>
 ```jsx template.tsx
-import { CSS } from "@onedoc/react-print/server";
+import { CSS } from "@onedoc/react-print";
 
 <React.Fragment>
   <CSS>
@@ -91,7 +91,7 @@ You can use the `@page` at-rule in CSS to manage all aspects of printed pages. M
 
 <div style={{paddingTop: "1rem", paddingBottom: "1rem"}}><CodeGroup>
 ```jsx template.tsx
-import { CSS } from "@onedoc/react-print/server";
+import { CSS } from "@onedoc/react-print";
 
 <React.Fragment>
   <CSS>{`@page {size: A4;margin-top:1cm;margin-right:1cm;margin-left:1cm;margin-bottom:1cm;`}</CSS>

--- a/docs/components/footnote.mdx
+++ b/docs/components/footnote.mdx
@@ -24,7 +24,7 @@ Creates an automatically numbered footnote. This will remove the footnote conten
 
 <div style={{paddingTop: "1rem", paddingBottom: "1rem"}}><CodeGroup>
 ```jsx template.tsx
-import { Footnote } from "@onedoc/react-print/server";
+import { Footnote } from "@onedoc/react-print";
 
 <Footnote>This is a sample footnote.</Footnote>;
 

--- a/docs/components/latex.mdx
+++ b/docs/components/latex.mdx
@@ -30,7 +30,7 @@ Support
 
 <div style={{paddingTop: "1rem", paddingBottom: "1rem"}}><CodeGroup>
 ```jsx template.tsx
-import { Latex } from "@onedoc/react-print/server";
+import { Latex } from "@onedoc/react-print";
 
 <Latex>{String.raw`\frac{1}{2}`}</Latex>;
 
@@ -57,7 +57,7 @@ body {
 
 <div style={{paddingTop: "1rem", paddingBottom: "1rem"}}><CodeGroup>
 ```jsx template.tsx
-import { Latex } from "@onedoc/react-print/server";
+import { Latex } from "@onedoc/react-print";
 
 <Latex>{String.raw`% \f is defined as #1f(#2) using the macro
 \f\relax{x} = \int_{-\infty}^\infty

--- a/docs/components/markdown.mdx
+++ b/docs/components/markdown.mdx
@@ -26,7 +26,7 @@ Support
 
 <div style={{paddingTop: "1rem", paddingBottom: "1rem"}}><CodeGroup>
 ```jsx template.tsx
-import { Markdown } from "@onedoc/react-print/server";
+import { Markdown } from "@onedoc/react-print";
 
 <Markdown>{`# Hello, world!
 
@@ -61,7 +61,7 @@ You can leverage the `overrides` prop to replace Markdown components with your o
 
 <div style={{paddingTop: "1rem", paddingBottom: "1rem"}}><CodeGroup>
 ```jsx template.tsx
-import { Markdown } from "@onedoc/react-print/server";
+import { Markdown } from "@onedoc/react-print";
 
 <Markdown
   options={{

--- a/docs/components/shell.mdx
+++ b/docs/components/shell.mdx
@@ -26,7 +26,7 @@ This component should be placed as early as possible in the document and will ap
 
 <div style={{paddingTop: "1rem", paddingBottom: "1rem"}}><CodeGroup>
 ```jsx template.tsx
-import { PageTop } from "@onedoc/react-print/server";
+import { PageTop } from "@onedoc/react-print";
 
 <PageTop style={{ backgroundColor: "#bfdbfe" }} />;
 
@@ -62,7 +62,7 @@ Displays content in the top of the current page.
 This component will override the content of the `PageTop` component for the current page.
 
 ```jsx
-import { CurrentPageTop } from "@onedoc/react-print/server";
+import { CurrentPageTop } from "@onedoc/react-print";
 ```
 
 ## PageBottom
@@ -85,7 +85,7 @@ Displays content in the bottom of all the pages.
 
 <div style={{paddingTop: "1rem", paddingBottom: "1rem"}}><CodeGroup>
 ```jsx template.tsx
-import { PageBottom } from "@onedoc/react-print/server";
+import { PageBottom } from "@onedoc/react-print";
 
 <PageBottom style={{ backgroundColor: "#bfdbfe" }} />;
 
@@ -119,7 +119,7 @@ Support
 Forces a page break.
 
 ```jsx
-import { PageBreak } from "@onedoc/react-print/server";
+import { PageBreak } from "@onedoc/react-print";
 ```
 
 ## NoBreak
@@ -135,7 +135,7 @@ Support
 Prevents a page break. Wrap this component around content that should not be broken across pages.
 
 ```jsx
-import { NoBreak } from "@onedoc/react-print/server";
+import { NoBreak } from "@onedoc/react-print";
 ```
 
 ## FloatBottom
@@ -158,7 +158,7 @@ Floats the content to the bottom of the page.
 
 <div style={{paddingTop: "1rem", paddingBottom: "1rem"}}><CodeGroup>
 ```jsx template.tsx
-import { FloatBottom } from "@onedoc/react-print/server";
+import { FloatBottom } from "@onedoc/react-print";
 
 <FloatBottom>Here are some floated contents</FloatBottom>;
 

--- a/docs/components/tailwind.mdx
+++ b/docs/components/tailwind.mdx
@@ -26,7 +26,7 @@ Support
 
 <div style={{paddingTop: "1rem", paddingBottom: "1rem"}}><CodeGroup>
 ```jsx template.tsx
-import { Tailwind } from "@onedoc/react-print/server";
+import { Tailwind } from "@onedoc/react-print";
 
 <Tailwind>
   <div className="bg-gradient-to-tr from-blue-500 to-blue-700 rounded-2xl p-12"></div>
@@ -61,7 +61,7 @@ You can also pass a custom Tailwind config to the Tailwind component.
 
 <div style={{paddingTop: "1rem", paddingBottom: "1rem"}}><CodeGroup>
 ```jsx template.tsx
-import { Tailwind } from "@onedoc/react-print/server";
+import { Tailwind } from "@onedoc/react-print";
 
 <Tailwind
   config={{

--- a/docs/components/variables.mdx
+++ b/docs/components/variables.mdx
@@ -24,7 +24,7 @@ Returns the current page number.
 
 <div style={{paddingTop: "1rem", paddingBottom: "1rem"}}><CodeGroup>
 ```jsx template.tsx
-import { PageNumber } from "@onedoc/react-print/server";
+import { PageNumber } from "@onedoc/react-print";
 
 <PageNumber counterStyle="decimal" />;
 
@@ -53,7 +53,7 @@ You can use a custom CSS counter-style, by passing a known name or a custom coun
 
 <div style={{paddingTop: "1rem", paddingBottom: "1rem"}}><CodeGroup>
 ```jsx template.tsx
-import { PageNumber } from "@onedoc/react-print/server";
+import { PageNumber } from "@onedoc/react-print";
 
 <PageNumber counterStyle="lower-roman" />;
 
@@ -106,7 +106,7 @@ Returns the total number of pages.
 
 <div style={{paddingTop: "1rem", paddingBottom: "1rem"}}><CodeGroup>
 ```jsx template.tsx
-import { PagesNumber, PageNumber } from "@onedoc/react-print/server";
+import { PagesNumber, PageNumber } from "@onedoc/react-print";
 
 <>
   <PageNumber counterStyle="decimal" />
@@ -165,7 +165,7 @@ Show the current running header of level 1 in the page header. All running heade
 
 <div style={{paddingTop: "1rem", paddingBottom: "1rem"}}><CodeGroup>
 ```jsx template.tsx
-import { RunningH1 } from "@onedoc/react-print/server";
+import { RunningH1 } from "@onedoc/react-print";
 
 <React.Fragment>
   <PageTop style={{ paddingTop: "1rem" }}>
@@ -204,7 +204,7 @@ Support
 Returns the current page's running header of level 2.
 
 ```jsx
-import { RunningH2 } from "@onedoc/react-print/server";
+import { RunningH2 } from "@onedoc/react-print";
 ```
 
 ## RunningH3
@@ -220,7 +220,7 @@ Support
 Returns the current page's running header of level 3.
 
 ```jsx
-import { RunningH3 } from "@onedoc/react-print/server";
+import { RunningH3 } from "@onedoc/react-print";
 ```
 
 ## RunningH4
@@ -236,7 +236,7 @@ Support
 Returns the current page's running header of level 4.
 
 ```jsx
-import { RunningH4 } from "@onedoc/react-print/server";
+import { RunningH4 } from "@onedoc/react-print";
 ```
 
 ## RunningH5
@@ -252,7 +252,7 @@ Support
 Returns the current page's running header of level 5.
 
 ```jsx
-import { RunningH5 } from "@onedoc/react-print/server";
+import { RunningH5 } from "@onedoc/react-print";
 ```
 
 ## RunningH6
@@ -268,6 +268,6 @@ Support
 Returns the current page's running header of level 6.
 
 ```jsx
-import { RunningH6 } from "@onedoc/react-print/server";
+import { RunningH6 } from "@onedoc/react-print";
 ```
 

--- a/src/compile/compile.tsx
+++ b/src/compile/compile.tsx
@@ -27,6 +27,8 @@ export const compile = async (
 
   const ReactDOMServer = await import("react-dom/server");
 
+  console.log(ReactDOMServer);
+
   let Element = (
     <>
       <CSS>{onedocStyles}</CSS>

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -22,5 +22,6 @@ export default defineConfig({
     };
   },
   esbuildPlugins: [RawPlugin(), plugin(stdLibBrowser)],
+  external: ["react", "react-dom"],
   bundle: true,
 });


### PR DESCRIPTION
Removes the `/server` import given that `/server` and `/client` are now cross-compatible.