### PR TITLE
FIXED: Documentation could be clearer (ISSUE#12)

### DIFF
--- a/docs/getting-started/setup.mdx
+++ b/docs/getting-started/setup.mdx
@@ -37,7 +37,7 @@ pnpm add @onedoc/react-print
 
 ## 3. Create your first PDF Component
 
-Create a new folder call `documents`, then create a new file inside call `index.jsx` and copy the following code:
+Create a new folder call `documents`, then create a new file inside call `index.tsx` and copy the following code:
 
 ```jsx document/index.tsx
 import { PageTop, PageBottom, PageBreak } from "@onedoc/react-print";


### PR DESCRIPTION
Issue: #12 

1. Correct the typo in the `docs/getting-started/setup.mdx`.
2. The issue mentions that the example document is named `document/index.tsx`, but the description incorrectly stated `index.jsx`. It has now been corrected to `index.tsx`.